### PR TITLE
Fix/new api syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # WitRuby Changelog
 All changes to this API wrapper will be documented in this file. This file follows the guidelines explained over at http://keepachangelog.com/.
 
+## 1.1.1 - 2014-06-30
+### Added
+- Added instance method, `entities`, for class Message that returns entities in result of a query
+- Added optional argument, index, for methods `confidence`, `entities`, `entity_names`, and `intent` that returns each value at the desired index. Defaults at 0 if no index is passed (this is in response to Wit returning more than one outcome).
+- Added ability to pass queries with spaces.
+
 ## 1.1.0 - 2014-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,10 +109,12 @@ To get a specific messages information from the wit.ai, pass in the message's ID
 
 ```ruby
 message_results = session.send_message("Your Message")
-message_results.confidence # Returns the confidence of the message results.
-message_results.entity_names # Generates array of names of each entity in this message.
-message_results.intent # Returns the intent that this message corresponded to.
+message_results.confidence(index=0) # Returns the confidence of the message results at the specified index.
+message_results.entities(index=0) # Returns the entities of the message results at the specified index.
+message_results.entity_names(index=0) # Generates array of names of each entity in this message at the specified index.
+message_results.intent(index=0) # Returns the intent that this message corresponded to at the specified index.
 ```
+*Index is an optional argument of type integer that lets you select the outcome at the specified index. The default index is 0.*
 
 ### Intent
 

--- a/lib/wit_ruby/rest/message.rb
+++ b/lib/wit_ruby/rest/message.rb
@@ -10,23 +10,23 @@ module Wit
       ## Returns the confidence of the message results.
       ##
       ## @return [Float] confidence in the message for the intent.
-      def confidence
-        outcomes[0]["confidence"]
+      def confidence(index=0)
+        outcomes[index]["confidence"]
       end
 
       ## Returns the intent that this message corresponded to.
       ##
       ## @return [String] intent name that this message corrsponded to.
-      def intent
-        outcomes[0]["intent"]
+      def intent(index=0)
+        outcomes[index]["intent"]
       end
 
       ## Generates Array of the names of each entity in this message.
       ##
       ## @return [Array] names of each entity
-      def entity_names
+      def entity_names(index=0)
         entity_arr = Array.new
-        outcomes[0]["entities"].each_key do |key|
+        outcomes[index]["entities"].each_key do |key|
           entity_arr << key
         end
         return entity_arr

--- a/lib/wit_ruby/rest/message.rb
+++ b/lib/wit_ruby/rest/message.rb
@@ -11,14 +11,14 @@ module Wit
       ##
       ## @return [Float] confidence in the message for the intent.
       def confidence
-        outcome["confidence"]
+        outcomes[0]["confidence"]
       end
 
       ## Returns the intent that this message corresponded to.
       ##
       ## @return [String] intent name that this message corrsponded to.
       def intent
-        outcome["intent"]
+        outcomes[0]["intent"]
       end
 
       ## Generates Array of the names of each entity in this message.
@@ -26,7 +26,7 @@ module Wit
       ## @return [Array] names of each entity
       def entity_names
         entity_arr = Array.new
-        outcome["entities"].each_key do |key|
+        outcomes[0]["entities"].each_key do |key|
           entity_arr << key
         end
         return entity_arr
@@ -40,8 +40,8 @@ module Wit
       ## @param possible_key [Symbol] possible method or key in the hash or entity.
       ## @return [Class] depending on the given results in the data.
       def method_missing(possible_key, *args, &block)
-        if @rawdata["outcome"]["entities"].has_key?(possible_key.to_s)
-          entity_value = @rawdata["outcome"]["entities"][possible_key.to_s]
+        if @rawdata["outcomes"][0]["entities"].has_key?(possible_key.to_s)
+          entity_value = @rawdata["outcomes"][0]["entities"][possible_key.to_s]
           entity_value.class == Hash ? Entity.new(entity_value) : EntityArray.new(entity_value)
         else
           super

--- a/lib/wit_ruby/rest/message.rb
+++ b/lib/wit_ruby/rest/message.rb
@@ -11,14 +11,21 @@ module Wit
       ##
       ## @return [Float] confidence in the message for the intent.
       def confidence(index=0)
-        outcomes[index]["confidence"]
+        self.raw_data["outcomes"][index]["confidence"]
       end
 
       ## Returns the intent that this message corresponded to.
       ##
       ## @return [String] intent name that this message corrsponded to.
       def intent(index=0)
-        outcomes[index]["intent"]
+        self.raw_data["outcomes"][index]["intent"]
+      end
+
+      ## Returns the entities that this message corresponded to.
+      ##
+      ## @return Hash of entities that this message corrsponded to.
+      def entities(index=0)
+        self.raw_data["outcomes"][index]["entities"]
       end
 
       ## Generates Array of the names of each entity in this message.
@@ -26,7 +33,7 @@ module Wit
       ## @return [Array] names of each entity
       def entity_names(index=0)
         entity_arr = Array.new
-        outcomes[index]["entities"].each_key do |key|
+        self.raw_data["outcomes"][index]["entities"].each_key do |key|
           entity_arr << key
         end
         return entity_arr

--- a/lib/wit_ruby/rest/result.rb
+++ b/lib/wit_ruby/rest/result.rb
@@ -104,7 +104,7 @@ module Wit
       ## @return [Array] entities in this current result object.
       def setup_entities
         ## Get the current entities hash
-        entities_raw = @rawdata["entities"] || @rawdata["outcome"]["entities"]
+        entities_raw = @rawdata["entities"] || @rawdata["outcomes"]["entities"]
         ## Set the intance variable to be an array containing these entities.
         ## If its empty, then set the instance variable to nil
         unless entities_raw.empty?

--- a/lib/wit_ruby/rest/session.rb
+++ b/lib/wit_ruby/rest/session.rb
@@ -25,6 +25,8 @@ module Wit
         if length <= 0 || length > 256
           raise NotCorrectSchema.new("The given message, \"#{message}\" is either too short or too long. Message length needs to be between 0 and 256.")
         end
+        # Replace spaces with "%20" for usage in URL
+        message.gsub!(" ", "%20")
         ## Recieve unwrapped results
         results = @client.get("/message?q=#{message}")
         return return_with_class(Wit::REST::Message, results)

--- a/spec/wit_ruby/rest/message_spec.rb
+++ b/spec/wit_ruby/rest/message_spec.rb
@@ -5,37 +5,35 @@
 require 'spec_helper'
 
 describe Wit::REST::Message do
-  let(:json) {%({
-  "msg_id": "ba0fcf60-44d3-4499-877e-c8d65c239730",
-  "msg_body": "how many people between Tuesday and Friday",
-  "outcome": {
-    "intent": "query_metrics",
-    "entities": {
-      "metric": {
-        "value": "metric_visitors",
-        "body": "people",
-        "metadata": "{'code' : 324}"
+  let(:json) {%(
+
+  {
+    "msg_id" : "c20ad081-2cb9-4c63-8dd6-6667409514fa",
+    "outcomes" : [ {
+      "_text" : "how many people between Tuesday and Friday",
+      "intent" : "query_metrics",
+      "entities" : {
+        "metric" : [ {
+          "metadata" : "{'code' : 324}",
+          "value" : "metric_visitor"
+        } ],
+        "datetime" : [ {
+          "value" : {
+            "from" : "2014-06-24T00:00:00.000+02:00",
+            "to" : "2014-06-25T00:00:00.000+02:00"
+          }
+        }, {
+          "value" : {
+            "from" : "2014-06-27T00:00:00.000+02:00",
+            "to" : "2014-06-28T00:00:00.000+02:00"
+          }
+        } ]
       },
-      "datetime": [
-        {
-          "value": {
-            "from": "2013-10-21T00:00:00.000Z",
-            "to": "2013-10-22T00:00:00.000Z"
-          },
-          "body": "Tuesday"
-        },
-        {
-          "value": {
-            "from": "2013-10-24T00:00:00.000Z",
-            "to": "2013-10-25T00:00:00.000Z"
-          },
-          "body": "Friday"
-        }
-      ]
-    },
-    "confidence": 0.979
+      "confidence" : 0.986
+    } ]
   }
-  })}
+
+  )}
   let(:rand_path) {"rand_path"}
   let(:rand_body) {"rand_body"}
   let(:rest_code) {"get"}
@@ -43,15 +41,15 @@ describe Wit::REST::Message do
 
 
   it "should have the following parameters, confidence and intent and entities" do
-    expect(message_results.confidence).to eql(0.979)
+    expect(message_results.confidence).to eql(0.986)
     expect(message_results.intent).to eql("query_metrics")
-    expect(message_results.metric.class).to eql(Wit::REST::Entity)
+    expect(message_results.metric.class).to eql(Wit::REST::EntityArray)
     expect(message_results.datetime.class).to eql(Wit::REST::EntityArray)
   end
 
   it "should have the right values in the entities" do
-    expect(message_results.metric.value).to eql("metric_visitors")
-    expect(message_results.datetime[0].body).to eql("Tuesday")
+    expect(message_results.metric[0].value).to eql("metric_visitor")
+    expect(message_results.datetime[0].value["from"]).to eql("2014-06-24T00:00:00.000+02:00")
   end
 
   it "should be able to return back an array of strings of the names of each entity" do

--- a/spec/wit_ruby/rest/session_spec.rb
+++ b/spec/wit_ruby/rest/session_spec.rb
@@ -181,7 +181,7 @@ describe Wit::REST::Session do
 
       it "should get back the same message and have the same has as the sent message results" do
         expect(@resulting_message.msg_id).to eql(sent_message_id)
-        expect(@resulting_message.msg_body).to eql(sent_message_result.msg_body)
+        expect(@resulting_message.outcomes[0]["_text"]).to eql(sent_message_result.outcomes[0]["_text"])
       end
     end
   end


### PR DESCRIPTION
Hello!

Recently, Wit structurally changed their return to queries. As you can see on their website (https://wit.ai/docs/api#span-classtitle-verb-getmessage), the example shows that more than one outcome can be returned in an array. We also found a few other things in the gem that we thought could use tweaking. We added all the changes we made to the changelog.

Hopefully you find these changes helpful. Thanks for a great gem!

Best,
@PWehlin & @rohitahuja
